### PR TITLE
Prevent tuple index out of range error

### DIFF
--- a/cmaputil/cmaputil.py
+++ b/cmaputil/cmaputil.py
@@ -153,8 +153,8 @@ def find_J_bounds(data, report=True):
     # Test each a'b' pair for their max and min J'
     minJ = 0
     maxJ = 100
-    # possible bug here when len(m.shape) == 1?
-    if m.shape[1] > 3:
+
+    if len(m.shape) > 1 and m.shape[1] > 3:
         for i in range(m.shape[1]):
             a = m[1, i]
             b = m[2, i]


### PR DESCRIPTION
The original line:

```
if m.shape[1] > 3:
```

will error out with `IndexError: tuple index out of range`. It's an error I get running the example program example2_cdpsPlots.py, for example. If you preface it with the conditional `if len(m.shape) > 1 and`, this will prevent the `tuple index out of range` error as Python will move on to the else statement as soon as the first conditional in a chained conditional is false.

Tested on Mac and Linux with example2_cdpsPlots.py.